### PR TITLE
Add permission node to /tpll (#106)

### DIFF
--- a/src/main/java/io/github/terra121/TerraMod.java
+++ b/src/main/java/io/github/terra121/TerraMod.java
@@ -18,6 +18,9 @@ import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 
+import net.minecraftforge.server.permission.DefaultPermissionLevel;
+import net.minecraftforge.server.permission.PermissionAPI;
+
 import io.github.terra121.letsencryptcraft.ILetsEncryptMod;
 import io.github.terra121.letsencryptcraft.LetsEncryptAdder;
 
@@ -49,6 +52,7 @@ public class TerraMod implements ILetsEncryptMod
     	MinecraftForge.TERRAIN_GEN_BUS.register(GenerationEventDenier.class);
     	MinecraftForge.EVENT_BUS.register(WaterDenier.class);
         MinecraftForge.EVENT_BUS.register(TerraConfig.class);
+	PermissionAPI.registerNode("terra121.commands.tpll", DefaultPermissionLevel.OP, "Allows a player to do /tpll");
     }
     
     @EventHandler

--- a/src/main/java/io/github/terra121/control/TerraTeleport.java
+++ b/src/main/java/io/github/terra121/control/TerraTeleport.java
@@ -12,6 +12,9 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
+// allow command usage via the permission node terra121.commands.tpll
+import net.minecraftforge.server.permission.PermissionAPI;
+import net.minecraft.entity.player.EntityPlayer;
 
 public class TerraTeleport extends CommandBase {
 
@@ -86,8 +89,11 @@ public class TerraTeleport extends CommandBase {
 				String.valueOf(proj[0]), alt, String.valueOf(proj[1])});
 		}
 	}
-
+	
 	private boolean isOp(ICommandSender sender) {
+		if (sender instanceof EntityPlayer) {
+			return PermissionAPI.hasPermission((EntityPlayer) sender, "terra121.commands.tpll");
+		}
 		return sender.canUseCommand(2, "");
 	}
 


### PR DESCRIPTION
* add permissions check to /tpll

* register permission node terra121.commands.tpll

You don't need the /tp command node. Also, if you're using ForgeEssentials, you need to give both the node and also commands.tpll. That's just a quirk with FE, however.